### PR TITLE
Fix Quora Share for Firefox 48

### DIFF
--- a/data/changeUrl.js
+++ b/data/changeUrl.js
@@ -1,10 +1,10 @@
 var fullUrl = window.location.href;
-if (!fullUrl.contains('share=1')) {
+if (!fullUrl.includes('share=1')) {
     // Add share=1 to reveal all posts
     var urlParts = fullUrl.split('#');
     var begin = urlParts[0];
     var hash = urlParts[1] ? '#' + urlParts[1] : '';
-    var delim = begin.contains('?') ? '&' : '?';
+    var delim = begin.includes('?') ? '&' : '?';
     var newUrl = begin + delim + 'share=1' + hash;
     history.replaceState({}, null, newUrl);
     window.location.reload();

--- a/data/changeUrl.js
+++ b/data/changeUrl.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fullUrl = window.location.href;
 if (!fullUrl.includes('share=1')) {
     // Add share=1 to reveal all posts

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var data = require("sdk/self").data;
 var pageMod = require("sdk/page-mod");
 pageMod.PageMod({

--- a/package.json
+++ b/package.json
@@ -6,5 +6,5 @@
     "author": "Fishkins",
     "homepage": "https://github.com/Fishkins/quoraShare",
     "license": "MPL 2.0",
-    "version": "0.1"
+    "version": "0.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,6 @@
     "author": "Fishkins",
     "homepage": "https://github.com/Fishkins/quoraShare",
     "license": "MPL 2.0",
+    "main": "lib/main.js",
     "version": "0.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "quorashare",
     "title": "Quora Share",
-    "id": "jid1-roegsJ40q6CsFg",
+    "id": "jid1-roegsJ40q6CsFg@jetpack",
     "description": "Show all Quora posts even when you aren't logged in",
     "author": "Fishkins",
     "homepage": "https://github.com/Fishkins/quoraShare",

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -1,4 +1,4 @@
-var main = require("./main");
+var main = require("../lib/main");
 
 exports["test main"] = function(assert) {
   assert.pass("Unit test running!");

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var main = require("../lib/main");
 
 exports["test main"] = function(assert) {


### PR DESCRIPTION
Quora Share no longer works in Firefox 48 because String#contains was removed ([bug 1102219](https://bugzilla.mozilla.org/show_bug.cgi?id=1102219)). String#contains was deprecated in Firefox 40 ([bug 1103588](https://bugzilla.mozilla.org/show_bug.cgi?id=1103588)). The fix is to replace calls to the nonstandard String#contains with the standard String#includes.

I also ported the add-on from cfx to [Jetpack's new jpm tool](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx_to_jpm).
